### PR TITLE
Update next timer while handling socket events

### DIFF
--- a/lua/coutil/socket.lua
+++ b/lua/coutil/socket.lua
@@ -49,7 +49,7 @@ setclock(gettime)
 
 local function idle(deadline)
 	repeat
-		local timeout = max(0, deadline - gettime())
+		local timeout = max(0, deadline() - gettime())
 		if not emitsockevents(timeout) then
 			suspendprocess(timeout)
 		end

--- a/lua/coutil/time.lua
+++ b/lua/coutil/time.lua
@@ -12,6 +12,7 @@ local timevt = require "coutil.time.event"
 local canceltimer = timevt.cancel
 local setuptimer = timevt.create
 local emituntil = timevt.emitall
+local dynnextwake = timevt.nextwake
 
 local function waitdone(timestamp, event, ...)
 	if event ~= timestamp then
@@ -51,7 +52,7 @@ function module.run(idle, timeout)
 			return nextwake
 		end
 		if nextwake > now then
-			idle(nextwake)
+			idle(dynnextwake)
 		end
 	end
 end

--- a/lua/coutil/time/event.lua
+++ b/lua/coutil/time/event.lua
@@ -69,4 +69,8 @@ function module.emitall(timestamp)
 	return waketimes[1]
 end
 
+function module.nextwake()
+	return waketimes[1]
+end
+
 return module


### PR DESCRIPTION
emitsockevents() can cause new timers to be created, any of which might
have a deadline sooner than the original nextwake value. So, update the
deadline in each iteration of idle() to make sure we're not starving any
such timers.