### PR TITLE
ssl: Check for verification errors before closing socket

### DIFF
--- a/lua/coutil/socket/ssl.lua
+++ b/lua/coutil/socket/ssl.lua
@@ -36,6 +36,15 @@ function CoSSL:dohandshake()
 		if errmsg == "wantwrite" then
 			write = self
 		elseif errmsg ~= "wantread" then
+			if not errmsg then
+				local verif_result
+				verif_result, errmsg = socket:getpeerverification()
+				if verif_result then
+					errmsg = "unknown handshake error"
+				else
+					errmsg = "TLS certificate invalid: " .. errmsg
+				end
+			end
 			socket:close()
 			break
 		end


### PR DESCRIPTION
This depends on https://github.com/getCUJO/libluasec/pull/2.

---

When the TLS certificate verification fails, the underlying
dohandshake() method fails without providing a proper error message.
getpeerverification() will provide a suitable error, but cannot be
called after the socket has been closed because closing deletes all the
underlying OpenSSL state. So the call has to be made specifically here.